### PR TITLE
Notification improvements

### DIFF
--- a/_config/passwords.yml
+++ b/_config/passwords.yml
@@ -3,6 +3,8 @@ Name: nswdpc-authentication-boilerplate-passwords
 After:
   - '#corepasswords'
 ---
+SilverStripe\Security\Member:
+  notify_password_change: true
 SilverStripe\Security\Security:
   # default password encryption
   password_encryption_algorithm: 'blowfish'

--- a/src/Admin/PendingProfile_ItemRequest.php
+++ b/src/Admin/PendingProfile_ItemRequest.php
@@ -98,7 +98,7 @@ class PendingProfile_ItemRequest extends GridFieldDetailForm_ItemRequest {
         return $this->edit(Controller::curr()->getRequest());
     }
 
-    public function doNotifyApprovers() {
+    public function doNotifyApprovers($data, $form) {
         $admin = Permission::check('ADMIN');
         if(!$admin) {
             return $this->edit(Controller::curr()->getRequest());

--- a/src/Extensions/ProfileExtension.php
+++ b/src/Extensions/ProfileExtension.php
@@ -181,6 +181,19 @@ class ProfileExtension extends DataExtension {
             ];
         }
 
+        // Ignore 'Password' if the notify_password_change notification is active
+        if($this->owner->config()->get('notify_password_change')) {
+            $key = array_search('Password', $params['restrictFields']);
+            if($key !== false) {
+                unset($params['restrictFields'][$key]);
+            }
+        }
+
+        // no fields were marked as changed
+        if(empty($params['restrictFields'])) {
+            return;
+        }
+
         $fields = $this->owner->getFrontEndFields($params);
         $what = new ArrayList();
         foreach($fields as $field) {

--- a/src/Models/Notifier.php
+++ b/src/Models/Notifier.php
@@ -138,6 +138,11 @@ class Notifier {
 
         // approvers - based on permission
         $approvers = PendingProfile::getApprovers();
+        if(!$approvers || $approvers->count() == 0) {
+            Logger::log("Cannot sendAdministrationApprovalRequired as there are no approvers. Please create some with the 'Edit Pending Profile' permission.", "NOTICE");
+            return false;
+        }
+
         foreach($approvers as $approver) {
 
             // template data


### PR DESCRIPTION
## Changes

+ Fix: pass data and form to pending profile item request method (54bfa2e)
+ Enhancement: when there no approvers configured, log a message (2f68a3e)
+ Enhancement: flag whether the request for approval notification was sent (75d8687)
+ Enhancement: turn on `SilverStripe\Security\Member.notify_password_change` by default but handle in profile change notification to avoid duplicated notifications (6ab6a66 )