### PR TITLE
NEW: notify when reset account process is started/completed.

### DIFF
--- a/_config/mfa.yml
+++ b/_config/mfa.yml
@@ -18,3 +18,7 @@ SilverStripe\MFA\BackupCode\RegisterHandler:
 # MFA setup
 NSWDPC\MFA\ConfigurationService:
   ss_mfa_secret_key: ''
+# Reset account notification
+SilverStripe\MFA\Extension\AccountReset\SecurityExtension:
+  extensions:
+    mfaResetAccountExtension: 'NSWDPC\Authentication\ResetAccountExtension'

--- a/src/Extensions/ResetAccountExtension.php
+++ b/src/Extensions/ResetAccountExtension.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace NSWDPC\Authentication;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Security\Member;
+
+/**
+ * Handle reset account notifications when that occurs
+ * @author James
+ */
+class ResetAccountExtension extends Extension
+{
+    /**
+     * @param Member $member
+     */
+    public function handleAccountReset(Member $member)
+    {
+        try {
+
+            // notify a group with a relevant permission
+            $notifier = Notifier::create();
+            return $notifier->sendMfaAccountResetNotification( $member,  'completed' );
+
+        } catch (\Exception $e) {
+
+        }
+
+        return false;
+    }
+}

--- a/templates/NSWDPC/MFA/Email/MemberResetAccountNotification.ss
+++ b/templates/NSWDPC/MFA/Email/MemberResetAccountNotification.ss
@@ -1,0 +1,22 @@
+
+<h1><%t NSWDPC\\Members\\Configuration.HI 'Hi' %> {$Recipient.FirstName}</h1>
+
+<% if $RequestState == 'started' %>
+    <p><%t NSWDPC\\Members\\Configuration.ACCOUNT_RESET_MFA_STARTED 'An MFA account reset token was validated' %>.</p>
+    <p><%t NSWDPC\\Members\\Configuration.ACCOUNT_RESET_MFA_STARTED_NEXT 'If completed, you will be notified' %>.</p>
+<% else %>
+    <%-- completed --%>
+    <p><%t NSWDPC\\Members\\Configuration.ACCOUNT_RESET_MFA_COMPLETED 'An account was reset via the MFA reset process' %>.</p>
+<% end_if %>
+
+<p><%t NSWDPC\\Members\\Configuration.ACCOUNT_RESET_MFA_MEMBER_DETAILS 'Account details' %><p>
+<ul>
+<% with $ResettingMember %>
+<li><%t NSWDPC\\Members\\Configuration.ACCOUNT_RESET_MFA_MEMBER_NAME 'Name' %>: {$Name.XML}</li>
+<li><%t NSWDPC\\Members\\Configuration.ACCOUNT_RESET_MFA_MEMBER_EMAIL 'Email' %>: {$Email.XML}</li>
+<% end_with %>
+<li><%t NSWDPC\\Members\\Configuration.ACCOUNT_RESET_MFA_BROWSER 'Browser' %>: {$Browser.XML}</li>
+<li><%t NSWDPC\\Members\\Configuration.ACCOUNT_RESET_MFA_REQUESTIP 'IP' %>: {$RequestIP.XML}</li>
+</ul>
+
+<p><%t NSWDPC\\Members\\Configuration.ACCOUNT_RESET_MFA_CHECKUP 'If these details are not as expected, please review the account' %>.</p>


### PR DESCRIPTION
## Changes

+ New: ResetAccountExtension for `handleAccountReset` operation
+ New: sendMfaAccountResetNotification - sends reset notification to members with the MFA_ADMINISTER_REGISTERED_METHODS permission
+ New: send notification on reset completion